### PR TITLE
feat/i29 :sparkles: Adiciona caso de uso para atualizar cliente

### DIFF
--- a/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/DefaultUpdateClientUseCase.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/DefaultUpdateClientUseCase.java
@@ -1,0 +1,53 @@
+package org.diegosneves.exactprocmmsbackend.application.client.update;
+
+import io.vavr.control.Either;
+import org.diegosneves.exactprocmmsbackend.domain.client.Client;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientGateway;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
+import org.diegosneves.exactprocmmsbackend.domain.exceptions.DomainException;
+import org.diegosneves.exactprocmmsbackend.domain.validation.ErrorData;
+import org.diegosneves.exactprocmmsbackend.domain.validation.handler.Notification;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static io.vavr.API.Left;
+import static io.vavr.API.Try;
+
+public class DefaultUpdateClientUseCase extends UpdateClientUseCase {
+
+    public static final String CLIENT_NOT_FOUND_MESSAGE = "Não foi encontrado o cliente com o ID %s";
+
+    private final ClientGateway clientGateway;
+
+    public DefaultUpdateClientUseCase(ClientGateway clientGateway) {
+        this.clientGateway = Objects.requireNonNull(clientGateway);
+    }
+
+    @Override
+    public Either<Notification, UpdateClientOutput> execute(final UpdateClientCommand aCommand) {
+        final var anId = ClientID.from(aCommand.id());
+
+        final var foundClient = this.clientGateway.findById(anId).orElseThrow(notFound(anId));
+
+        final var notification = Notification.create();
+        foundClient.update(
+                aCommand.cnpj(),
+                aCommand.address(),
+                aCommand.contact(),
+                aCommand.companyName(),
+                aCommand.companyBrach(),
+                aCommand.companySector()).validate(notification);
+        return notification.hasError() ? Left(notification) : this.updated(foundClient);
+    }
+
+    private Either<Notification, UpdateClientOutput> updated(final Client aClient) {
+        return Try(() -> this.clientGateway.update(aClient))
+                .toEither()
+                .bimap(Notification::create, UpdateClientOutput::from);
+    }
+
+    private static Supplier<DomainException> notFound(final ClientID anId) {
+        return () -> DomainException.with(new ErrorData(CLIENT_NOT_FOUND_MESSAGE.formatted(anId.getValue())));
+    }
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientCommand.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientCommand.java
@@ -1,0 +1,27 @@
+package org.diegosneves.exactprocmmsbackend.application.client.update;
+
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.Address;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.ClientContact;
+
+public record UpdateClientCommand(
+        String id,
+        String cnpj,
+        Address address,
+        ClientContact contact,
+        String companyName,
+        String companyBrach,
+        String companySector) {
+
+    public static UpdateClientCommand with(
+            final String id,
+            final String cnpj,
+            final Address address,
+            final ClientContact contact,
+            final String companyName,
+            final String companyBrach,
+            final String companySector) {
+
+        return new UpdateClientCommand(id, cnpj, address, contact, companyName, companyBrach, companySector);
+    }
+
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientOutput.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientOutput.java
@@ -1,0 +1,12 @@
+package org.diegosneves.exactprocmmsbackend.application.client.update;
+
+import org.diegosneves.exactprocmmsbackend.domain.client.Client;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
+
+public record UpdateClientOutput(ClientID clientID) {
+
+    public static UpdateClientOutput from(Client aClient) {
+        return new UpdateClientOutput(aClient.getId());
+    }
+
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientUseCase.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientUseCase.java
@@ -1,0 +1,9 @@
+package org.diegosneves.exactprocmmsbackend.application.client.update;
+
+import io.vavr.control.Either;
+import org.diegosneves.exactprocmmsbackend.application.UseCase;
+import org.diegosneves.exactprocmmsbackend.domain.validation.handler.Notification;
+
+public abstract class UpdateClientUseCase extends UseCase<UpdateClientCommand, Either<Notification, UpdateClientOutput>> {
+
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/domain/Identifier.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/domain/Identifier.java
@@ -1,4 +1,7 @@
 package org.diegosneves.exactprocmmsbackend.domain;
 
 public abstract class Identifier extends ValueObject {
+
+    public abstract String getValue();
+
 }

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/Client.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/Client.java
@@ -8,12 +8,12 @@ import org.diegosneves.exactprocmmsbackend.domain.validation.ValidationHandler;
 
 public class Client extends Entity<ClientID> {
 
-    private final String cnpj;
-    private final Address address;
-    private final ClientContact contact;
-    private final String companyName;
-    private final String companyBranch;
-    private final String companySector;
+    private String cnpj;
+    private Address address;
+    private ClientContact contact;
+    private String companyName;
+    private String companyBranch;
+    private String companySector;
 
     private Client(final ClientID id, final String cnpj, final Address address, final ClientContact contact, final String companyName, final String companyBranch, final String companySector) {
         super(id);
@@ -28,6 +28,17 @@ public class Client extends Entity<ClientID> {
     public static Client newClient(final String cnpj, final Address address, final ClientContact contact, final String companyName, final String companyBranch, final String companySector) {
         final var id = ClientID.unique();
         return new Client(id, Cleaner.string(cnpj), address, contact, Cleaner.string(companyName), Cleaner.string(companyBranch), Cleaner.string(companySector));
+    }
+
+    public Client update(final String cnpj, final Address address, final ClientContact contact, final String companyName, final String companyBranch, final String companySector) {
+        this.cnpj = cnpj;
+        this.address = address;
+        this.contact = contact;
+        this.companyName = companyName;
+        this.companyBranch = companyBranch;
+        this.companySector = companySector;
+
+        return this;
     }
 
     public String getCnpj() {

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/ClientID.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/ClientID.java
@@ -2,6 +2,7 @@ package org.diegosneves.exactprocmmsbackend.domain.client;
 
 import org.diegosneves.exactprocmmsbackend.domain.Identifier;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public class ClientID extends Identifier {
@@ -24,4 +25,21 @@ public class ClientID extends Identifier {
         return new ClientID(value);
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        ClientID clientID = (ClientID) object;
+        return Objects.equals(getValue(), clientID.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getValue());
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
 }

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/domain/report/ReportID.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/domain/report/ReportID.java
@@ -24,4 +24,8 @@ public class ReportID extends Identifier {
         return new ReportID(value.toString().toLowerCase());
     }
 
+    @Override
+    public String getValue() {
+        return this.value;
+    }
 }

--- a/src/test/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientUseCaseTest.java
+++ b/src/test/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientUseCaseTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -123,7 +122,7 @@ class UpdateClientUseCaseTest {
 
         final var expectedId = ClientID.from("f89f392c-8429-4760-9f39-2c8429876052");
 
-        when(this.clientGateway.findById(eq(expectedId))).thenReturn(Optional.empty());
+        when(this.clientGateway.findById(expectedId)).thenReturn(Optional.empty());
 
         final var aCommand = UpdateClientCommand.with(
                 expectedId.getValue(),
@@ -136,7 +135,7 @@ class UpdateClientUseCaseTest {
 
         final var actualOutput = assertThrows(DomainException.class, () -> this.useCase.execute(aCommand));
 
-        verify(this.clientGateway, times(1)).findById(eq(expectedId));
+        verify(this.clientGateway, times(1)).findById(expectedId);
         verify(this.clientGateway, never()).update(any());
 
         assertNotNull(actualOutput);

--- a/src/test/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientUseCaseTest.java
+++ b/src/test/java/org/diegosneves/exactprocmmsbackend/application/client/update/UpdateClientUseCaseTest.java
@@ -1,0 +1,147 @@
+package org.diegosneves.exactprocmmsbackend.application.client.update;
+
+import org.diegosneves.exactprocmmsbackend.domain.client.Client;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientGateway;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.Address;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.ClientContact;
+import org.diegosneves.exactprocmmsbackend.domain.exceptions.DomainException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateClientUseCaseTest {
+
+    @InjectMocks
+    private DefaultUpdateClientUseCase useCase;
+
+    @Mock
+    private ClientGateway clientGateway;
+
+    @Test
+    void shouldCreateClientGivenValidInput() {
+        final var expectedCnpj = "34494244000190";
+        final var expectedAddress = new Address("Rua", "333", "Bairro", "Cidade", "RS", "82456789");
+        final var oldAddress = new Address("Rua2", "3332", "Bairro2", "Cidade2", "RS", "824567892");
+        final var expectedContact = new ClientContact("email@email.com", "12334567896");
+        final var oldContact = new ClientContact("email2@email.com", "11111111");
+        final var expectedCompanyName = "Company Name";
+        final var expectedCompanyBranch = "Company Branch";
+        final var expectedCompanySector = "Company Sector";
+
+        final var aClient = Client.newClient("90.265.697/0001-15", oldAddress, oldContact, "expectedCompanyName", "expectedCompanyBranch", "expectedCompanySector");
+        final var expectedId = aClient.getId();
+
+        when(this.clientGateway.findById(expectedId)).thenReturn(Optional.of(aClient));
+        when(this.clientGateway.update(any(Client.class))).thenAnswer(returnsFirstArg());
+
+        final var aCommand = UpdateClientCommand.with(
+                expectedId.getValue(),
+                expectedCnpj,
+                expectedAddress,
+                expectedContact,
+                expectedCompanyName,
+                expectedCompanyBranch,
+                expectedCompanySector);
+
+        final var actualOutput = this.useCase.execute(aCommand).get();
+
+        verify(this.clientGateway, times(1)).findById(expectedId);
+        verify(this.clientGateway, times(1)).update(argThat(updateClient -> Objects.equals(expectedId.getValue(), updateClient.getId().getValue()) &&
+                Objects.equals(expectedCnpj, updateClient.getCnpj()) &&
+                Objects.equals(expectedAddress, updateClient.getAddress()) &&
+                Objects.equals(expectedContact, updateClient.getContact()) &&
+                Objects.equals(expectedCompanyName, updateClient.getCompanyName()) &&
+                Objects.equals(expectedCompanyBranch, updateClient.getCompanyBranch()) &&
+                Objects.equals(expectedCompanySector, updateClient.getCompanySector())));
+
+        assertNotNull(actualOutput);
+        assertNotNull(actualOutput.clientID());
+    }
+
+    @Test
+    void givenAnInvalidParamWhenUpdateClientUseCaseShouldThrowException() {
+        final var expectedCnpj = "34494244000191";
+        final var expectedAddress = new Address("Rua", "333", "Bairro", "Cidade", "RS", "82456789");
+        final var oldAddress = new Address("Rua2", "3332", "Bairro2", "Cidade2", "RS", "824567892");
+        final var expectedContact = new ClientContact("email@email.com", "12334567896");
+        final var oldContact = new ClientContact("email2@email.com", "11111111");
+        final var expectedCompanyName = "Company Name";
+        final var expectedCompanyBranch = "Company Branch";
+        final var expectedCompanySector = "Company Sector";
+
+        final var aClient = Client.newClient("90.265.697/0001-15", oldAddress, oldContact, "expectedCompanyName", "expectedCompanyBranch", "expectedCompanySector");
+        final var expectedId = aClient.getId();
+
+        when(this.clientGateway.findById(expectedId)).thenReturn(Optional.of(aClient));
+
+        final var aCommand = UpdateClientCommand.with(
+                expectedId.getValue(),
+                expectedCnpj,
+                expectedAddress,
+                expectedContact,
+                expectedCompanyName,
+                expectedCompanyBranch,
+                expectedCompanySector);
+
+        final var actualOutput = this.useCase.execute(aCommand).getLeft();
+
+        verify(this.clientGateway, times(1)).findById(expectedId);
+        verify(this.clientGateway, never()).update(any());
+
+        assertNotNull(actualOutput);
+        assertEquals(1, actualOutput.getErrors().size());
+        assertEquals("O segundo dígito verificador do CNPJ não é válido.", actualOutput.findFirst().message());
+    }
+
+    @Test
+    void givenAnInvalidIDWhenUpdateClientUseCaseShouldThrowException() {
+        final var expectedCnpj = "34494244000190";
+        final var expectedAddress = new Address("Rua", "333", "Bairro", "Cidade", "RS", "82456789");
+        final var expectedContact = new ClientContact("email@email.com", "12334567896");
+        final var expectedCompanyName = "Company Name";
+        final var expectedCompanyBranch = "Company Branch";
+        final var expectedCompanySector = "Company Sector";
+
+        final var expectedId = ClientID.from("f89f392c-8429-4760-9f39-2c8429876052");
+
+        when(this.clientGateway.findById(eq(expectedId))).thenReturn(Optional.empty());
+
+        final var aCommand = UpdateClientCommand.with(
+                expectedId.getValue(),
+                expectedCnpj,
+                expectedAddress,
+                expectedContact,
+                expectedCompanyName,
+                expectedCompanyBranch,
+                expectedCompanySector);
+
+        final var actualOutput = assertThrows(DomainException.class, () -> this.useCase.execute(aCommand));
+
+        verify(this.clientGateway, times(1)).findById(eq(expectedId));
+        verify(this.clientGateway, never()).update(any());
+
+        assertNotNull(actualOutput);
+        assertEquals(1, actualOutput.getErrors().size());
+        assertEquals(DefaultUpdateClientUseCase.CLIENT_NOT_FOUND_MESSAGE.formatted(expectedId.getValue()), actualOutput.getErrors().get(0).message());
+    }
+
+}

--- a/src/test/java/org/diegosneves/exactprocmmsbackend/domain/client/ClientIDTest.java
+++ b/src/test/java/org/diegosneves/exactprocmmsbackend/domain/client/ClientIDTest.java
@@ -1,0 +1,57 @@
+package org.diegosneves.exactprocmmsbackend.domain.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClientIDTest {
+
+    @Test
+    void shouldGenerateAndReturnEqualsClientID() {
+        final var aClientID = ClientID.unique();
+        final var bClientID = aClientID;
+
+        assertNotNull(aClientID);
+        assertEquals(aClientID, bClientID);
+    }
+
+    @Test
+    void shouldGenerateAndReturnNotEqualsClientID() {
+        final var aClientID = ClientID.unique();
+        final var bClientID = ClientID.unique();
+
+        assertNotNull(aClientID);
+        assertNotNull(bClientID);
+        assertNotEquals(aClientID, bClientID);
+    }
+
+    @Test
+    void shouldGenerateClientIDAndEnsureNotEqualsNull() {
+        final var aClientID = ClientID.unique();
+        ClientID bClientID = null;
+        boolean isEqual = aClientID.equals(bClientID);
+
+        assertNotNull(aClientID);
+        assertFalse(isEqual);
+    }
+
+    @Test
+    void shouldNotEqualItsStringValue() {
+        final var aClientID = ClientID.unique();
+        final var nonClientID = aClientID.getValue();
+        boolean isEqual = aClientID.equals(nonClientID);
+
+        assertNotNull(aClientID);
+        assertFalse(isEqual);
+    }
+
+    @Test
+    void should() {
+        final var aClientID = ClientID.unique();
+        int hashCode = aClientID.hashCode();
+
+        assertNotNull(aClientID);
+        assertNotEquals(0, hashCode);
+    }
+
+}


### PR DESCRIPTION
**Commit** b9e44a10378a97119fd6b8f0c6d83fbfcbf785ad:

Este commit adiciona a funcionalidade para atualização de clientes na aplicação. A implementação inclui a lógica do caso de uso, comandos, saída e a classe abstrata para suportar a atualização dos dados dos clientes. Além disso, foram criados testes unitários cobrindo cenários de sucesso e falha para garantir a robustez da funcionalidade.

**Arquivos Alterados:** `DefaultUpdateClientUseCase.java`, `UpdateClientCommand.java`, `UpdateClientOutput.java`, `UpdateClientUseCase.java`, `UpdateClientUseCaseTest.java`

**Alterações:**

- Adicionada a classe `DefaultUpdateClientUseCase` que contém a lógica para atualização de clientes. Esta classe verifica a existência do cliente, atualiza seus dados e valida a operação antes de persistir a atualização.
- Criado o `UpdateClientCommand`, um comando que encapsula os dados necessários para a atualização do cliente.
- Adicionada a classe `UpdateClientOutput` que encapsula a saída do caso de uso, retornando o ID do cliente atualizado.
- Implementada a classe abstrata `UpdateClientUseCase` que define a assinatura do caso de uso de atualização.
- Incluídos testes na classe `UpdateClientUseCaseTest` para cobrir cenários de atualização de cliente com dados válidos e inválidos, verificando a correta execução e validação dos dados.

**Nota:** Este commit introduz um caso de uso importante para a funcionalidade de atualização de clientes, assegurando que a lógica de negócio e validação sejam aplicadas adequadamente antes de qualquer operação de persistência, além de melhorar a cobertura de testes do projeto.