### PR TITLE
feat/i31 :sparkles: Implement delete client use case

### DIFF
--- a/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/delete/DefaultDeleteClientUseCase.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/delete/DefaultDeleteClientUseCase.java
@@ -1,0 +1,20 @@
+package org.diegosneves.exactprocmmsbackend.application.client.delete;
+
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientGateway;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
+
+import java.util.Objects;
+
+public class DefaultDeleteClientUseCase extends DeleteClientUseCase {
+
+    private final ClientGateway clientGateway;
+
+    public DefaultDeleteClientUseCase(final ClientGateway clientGateway) {
+        this.clientGateway = Objects.requireNonNull(clientGateway);
+    }
+
+    @Override
+    public void execute(final String id) {
+        this.clientGateway.deleteById(ClientID.from(id));
+    }
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/delete/DeleteClientUseCase.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/application/client/delete/DeleteClientUseCase.java
@@ -1,0 +1,7 @@
+package org.diegosneves.exactprocmmsbackend.application.client.delete;
+
+import org.diegosneves.exactprocmmsbackend.application.UnitUseCase;
+
+public abstract class DeleteClientUseCase extends UnitUseCase<String> {
+
+}

--- a/src/test/java/org/diegosneves/exactprocmmsbackend/application/client/delete/DeleteClientUseCaseTest.java
+++ b/src/test/java/org/diegosneves/exactprocmmsbackend/application/client/delete/DeleteClientUseCaseTest.java
@@ -1,0 +1,82 @@
+package org.diegosneves.exactprocmmsbackend.application.client.delete;
+
+import org.diegosneves.exactprocmmsbackend.domain.client.Client;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientGateway;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.Address;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.ClientContact;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteClientUseCaseTest {
+
+    @InjectMocks
+    private DefaultDeleteClientUseCase useCase;
+
+    @Mock
+    private ClientGateway clientGateway;
+
+    @BeforeEach
+    void cleanUp() {
+        Mockito.reset(clientGateway);
+    }
+
+    @Test
+    void shouldDeleteClientWhenReceiveAValidID() {
+        final var expectedAddress = new Address("Rua", "333", "Bairro", "Cidade", "RS", "82456789");
+        final var expectedContact = new ClientContact("email@email.com", "12334567896");
+        final var aClient = Client.newClient("90.265.697/0001-15", expectedAddress, expectedContact, "expectedCompanyName", "expectedCompanyBranch", "expectedCompanySector");
+        final var expectedId = aClient.getId();
+
+        doNothing().when(this.clientGateway).deleteById(expectedId);
+
+        assertDoesNotThrow(() -> this.useCase.execute(expectedId.getValue()));
+
+        verify(this.clientGateway, times(1)).deleteById(expectedId);
+
+    }
+
+    @Test
+    void shouldNotDeleteClientWhenReceiveAnInvalidID() {
+        final var expectedId = ClientID.from("123456789");
+
+        doNothing().when(this.clientGateway).deleteById(expectedId);
+
+        assertDoesNotThrow(() -> this.useCase.execute(expectedId.getValue()));
+
+        verify(this.clientGateway, times(1)).deleteById(expectedId);
+    }
+
+    @Test
+    void shouldReturnAnExceptionWhenClientGatewayThrowsAnException() {
+        final var expectedAddress = new Address("Rua", "333", "Bairro", "Cidade", "RS", "82456789");
+        final var expectedContact = new ClientContact("email@email.com", "12334567896");
+        final var aClient = Client.newClient("90.265.697/0001-15", expectedAddress, expectedContact, "expectedCompanyName", "expectedCompanyBranch", "expectedCompanySector");
+        final var expectedId = aClient.getId();
+
+        doThrow(new IllegalStateException("Gateway Error")).when(this.clientGateway).deleteById(expectedId);
+
+        final var actualException = assertThrows(IllegalStateException.class, () -> this.useCase.execute(expectedId.getValue()));
+
+        verify(this.clientGateway, times(1)).deleteById(expectedId);
+
+        assertNotNull(actualException);
+        assertEquals(IllegalStateException.class, actualException.getClass());
+    }
+
+}


### PR DESCRIPTION
**Commit** a0e2b19810288dda49159339e29a2f9c4373e12c:

Este commit adiciona o caso de uso de deletar cliente na aplicação. Ele introduz a classe `DefaultDeleteClientUseCase` que utiliza o `ClientGateway` para realizar a operação de deleção. Além disso, uma classe abstrata `DeleteClientUseCase` foi criada para definir a interface do caso de uso, e testes foram adicionados para validar a funcionalidade.

**Arquivos Alterados:** 
- `DefaultDeleteClientUseCase.java`
- `DeleteClientUseCase.java`
- `DeleteClientUseCaseTest.java`

**Alterações:**

- Adicionada a classe `DefaultDeleteClientUseCase` na pasta `application/client/delete`, a qual implementa o método `execute` para deletar clientes usando o `ClientGateway`.
- Criada a classe abstrata `DeleteClientUseCase` na pasta `application/client/delete` que estende `UnitUseCase<String>`.
- Implementados testes na classe `DeleteClientUseCaseTest` para cobrir os seguintes cenários:
  - Deleção de cliente bem-sucedida quando um ID válido é fornecido.
  - Não lançar exceção para um ID inválido.
  - Lançar uma exceção apropriada quando o `ClientGateway` lança uma exceção.

**Nota:** O foco principal deste commit é adicionar um caso de uso para deletar clientes, garantindo que a operação seja coberta por testes unitários essenciais.

---