### PR TITLE
feat/i37 :arrow_up: Configurar Profiles do Spring Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # ExactPro CMMS - backend <img align="center" src="https://raw.githubusercontent.com/devicons/devicon/6910f0503efdd315c8f9b858234310c06e04d9c0/icons/linux/linux-original.svg" alt="Linux" width="40" height="40">
 
-<img align="center" alt="Diego-Spring" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/spring/spring-original.svg" />
-<img align="center" alt="Diego-Java" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" />  
-<img align="center" alt="Diego-Docker" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-plain.svg">
-<img align="center" alt="Diego-Kubernetes" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/kubernetes/kubernetes-plain.svg"/>
-<img align="center" src="https://raw.githubusercontent.com/devicons/devicon/6910f0503efdd315c8f9b858234310c06e04d9c0/icons/swagger/swagger-original.svg" alt="Swagger" width="40" height="30">
 
 ![Spring](https://img.shields.io/badge/Spring-6DB33F?style=plastic&logo=spring&logoColor=white)
 ![Java](https://img.shields.io/badge/Java-ED8B00?style=plastic&logo=openjdk&logoColor=white)

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/ExactproCmmsBackendApplication.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/ExactproCmmsBackendApplication.java
@@ -2,11 +2,13 @@ package org.diegosneves.exactprocmmsbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.core.env.AbstractEnvironment;
 
 @SpringBootApplication
 public class ExactproCmmsBackendApplication {
 
     public static void main(String[] args) {
+        System.setProperty(AbstractEnvironment.DEFAULT_PROFILES_PROPERTY_NAME, "development");
         SpringApplication.run(ExactproCmmsBackendApplication.class, args);
     }
 

--- a/src/main/resources/application-development.yaml
+++ b/src/main/resources/application-development.yaml
@@ -1,0 +1,10 @@
+server:
+  port: 8080
+  compression:
+    enabled: true
+    mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
+    min-response-size: 1024
+  undertow:
+    threads:
+      worker: 10
+      io: 2

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,13 @@
 server:
   port: 8080
+  compression:
+    enabled: true
+    mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
+    min-response-size: 1024
+  undertow:
+    threads:
+      worker: 64
+      io: 4
 
 spring:
   datasource:


### PR DESCRIPTION
- **Commit** 217dcd1b5ca50f6f1fd4da674e1567a6914d351f:

  - **Descrição**:
    - Atualizado o starter web do Spring Boot para Undertow no arquivo `pom.xml`.
    - Adicionada configuração de perfis de desenvolvimento no `application-development.yaml`.
    - Ajustes gerais no arquivo `application.yaml` para suportar a nova configuração.
    - Modificada a classe principal para definir o perfil padrão como "development".

  - **Arquivos Alterados**:
    - `pom.xml`
    - `application-development.yaml`
    - `application.yaml`
    - Classe Principal (não especificada no log)

  - **Alterações**:
    - **pom.xml**: Substituído o starter web do Spring Boot para utilizar Undertow.
    - **application-development.yaml**: Adicionadas propriedades específicas para o ambiente de desenvolvimento.
    - **application.yaml**: Ajustes gerais para integração com o Undertow e novos perfis.
    - **Classe Principal**: Adicionado código para definir o perfil padrão como "development".

  - **Nota**:
    - A principal ênfase deste commit é a adoção do Undertow como servidor web padrão e a configuração dos perfis específicos para desenvolvimento, garantindo melhor desempenho e flexibilidade.