### PR TITLE
feat/i38 :art: Adicione configuração de banco de dados H2 para testes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>test</scope>
+<!--            <scope>test</scope>-->
         </dependency>
 
         <!-- Junit 5 -->

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: root
+    password: 123456
+    url: jdbc:h2:mem:cmms;MODE=MYSQL;DATABASE_TO_LOWER=TRUE
+  jpa:
+    defer-datasource-initialization: true
+  h2:
+    console:
+      enabled: true
+      path: /h2


### PR DESCRIPTION
**Commit** 177b05ffa7b436301d970c4cf92bca4c099728d0:

Este commit adiciona a configuração do banco de dados H2 para facilitar a execução de testes de integração. Foi criado o arquivo `application-test.yaml` com as configurações necessárias para o H2 e ajustado o `pom.xml` para incluir a dependência do H2, removendo o escopo de teste.

**Arquivos Alterados:** `application-test.yaml`, `pom.xml`

**Alterações:**

- Criado o arquivo `application-test.yaml` para configurar o banco de dados H2 para o ambiente de teste.
- Ajustado o `pom.xml` para adicionar a dependência do H2 e remover o escopo de teste, permitindo que o H2 seja utilizado durante a execução dos testes.

**Nota:** Este commit facilita a configuração e execução de testes de integração ao utilizar o banco de dados em memória H2.