### PR TITLE
feat/i42 :sparkles: Adicione entidades JPA para Client, Address e ClientContact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
             **/org/diegosneves/exactprocmmsbackend/domain/Identifier.java,
             **/org/diegosneves/exactprocmmsbackend/domain/ValueObject.java,
             **/org/diegosneves/exactprocmmsbackend/domain/client/ClientSearchQuery.java,
+            **/org/diegosneves/exactprocmmsbackend/infrastructure/client/**,
             **/org/diegosneves/exactprocmmsbackend/ExactproCmmsBackendApplication.java
         </sonar.coverage.exclusions>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <!--            <scope>test</scope>-->
+            <scope>test</scope>
         </dependency>
 
         <!-- Junit 5 -->

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/Client.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/Client.java
@@ -30,6 +30,38 @@ public class Client extends Entity<ClientID> {
         return new Client(id, Cleaner.string(cnpj), address, contact, Cleaner.string(companyName), Cleaner.string(companyBranch), Cleaner.string(companySector));
     }
 
+    public static Client with(final Client aClient) {
+        return with(
+                aClient.getId(),
+                aClient.getCnpj(),
+                aClient.getAddress(),
+                aClient.getContact(),
+                aClient.getCompanyName(),
+                aClient.getCompanyBranch(),
+                aClient.getCompanySector()
+        );
+    }
+
+    public static Client with(
+            final ClientID anId,
+            final String cnpj,
+            final Address anAddress,
+            final ClientContact aContact,
+            final String companyName,
+            final String companyBranch,
+            final String companySector)
+    {
+        return new Client(
+                anId,
+                cnpj,
+                anAddress,
+                aContact,
+                companyName,
+                companyBranch,
+                companySector
+        );
+    }
+
     public Client update(final String cnpj, final Address address, final ClientContact contact, final String companyName, final String companyBranch, final String companySector) {
         this.cnpj = cnpj;
         this.address = address;

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/valueobject/Address.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/domain/client/valueobject/Address.java
@@ -19,7 +19,7 @@ public class Address {
     }
 
     public String getStreet() {
-        return street;
+        return this.street;
     }
 
     public void setStreet(String street) {
@@ -27,7 +27,7 @@ public class Address {
     }
 
     public String getNumber() {
-        return number;
+        return this.number;
     }
 
     public void setNumber(String number) {
@@ -35,7 +35,7 @@ public class Address {
     }
 
     public String getNeighborhood() {
-        return neighborhood;
+        return this.neighborhood;
     }
 
     public void setNeighborhood(String neighborhood) {
@@ -43,7 +43,7 @@ public class Address {
     }
 
     public String getCity() {
-        return city;
+        return this.city;
     }
 
     public void setCity(String city) {
@@ -51,7 +51,7 @@ public class Address {
     }
 
     public String getState() {
-        return state;
+        return this.state;
     }
 
     public void setState(String state) {
@@ -59,7 +59,7 @@ public class Address {
     }
 
     public String getZip() {
-        return zip;
+        return this.zip;
     }
 
     public void setZip(String zip) {

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/AddressJpaEntity.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/AddressJpaEntity.java
@@ -6,7 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.Address;
 
 import java.util.Objects;
@@ -14,6 +16,8 @@ import java.util.Objects;
 @Entity
 @Table(name = "addresses")
 @NoArgsConstructor
+@Getter
+@Setter
 public class AddressJpaEntity {
 
     @Id
@@ -58,61 +62,6 @@ public class AddressJpaEntity {
         );
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getStreet() {
-        return street;
-    }
-
-    public void setStreet(String street) {
-        this.street = street;
-    }
-
-    public String getNumber() {
-        return number;
-    }
-
-    public void setNumber(String number) {
-        this.number = number;
-    }
-
-    public String getNeighborhood() {
-        return neighborhood;
-    }
-
-    public void setNeighborhood(String neighborhood) {
-        this.neighborhood = neighborhood;
-    }
-
-    public String getCity() {
-        return city;
-    }
-
-    public void setCity(String city) {
-        this.city = city;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-
-    public String getZip() {
-        return zip;
-    }
-
-    public void setZip(String zip) {
-        this.zip = zip;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/AddressJpaEntity.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/AddressJpaEntity.java
@@ -1,0 +1,139 @@
+package org.diegosneves.exactprocmmsbackend.infrastructure.client.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.Address;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "addresses")
+@NoArgsConstructor
+public class AddressJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "street", nullable = false)
+    private String street;
+    @Column(name = "number", nullable = false)
+    private String number;
+    @Column(name = "neighborhood", nullable = false)
+    private String neighborhood;
+    @Column(name = "city", nullable = false)
+    private String city;
+    @Column(name = "state", nullable = false)
+    private String state;
+    @Column(name = "zip", nullable = false)
+    private String zip;
+
+    private AddressJpaEntity(
+            final String street,
+            final String number,
+            final String neighborhood,
+            final String city,
+            final String state,
+            final String zip) {
+        this.street = street;
+        this.number = number;
+        this.neighborhood = neighborhood;
+        this.city = city;
+        this.state = state;
+        this.zip = zip;
+    }
+
+    public static AddressJpaEntity from(final Address anAddress) {
+        return new AddressJpaEntity(
+                anAddress.getStreet(),
+                anAddress.getNumber(),
+                anAddress.getNeighborhood(),
+                anAddress.getCity(),
+                anAddress.getState(),
+                anAddress.getZip()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public String getNeighborhood() {
+        return neighborhood;
+    }
+
+    public void setNeighborhood(String neighborhood) {
+        this.neighborhood = neighborhood;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public void setZip(String zip) {
+        this.zip = zip;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressJpaEntity that = (AddressJpaEntity) o;
+        return Objects.equals(getNumber(), that.getNumber()) && Objects.equals(getZip(), that.getZip());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getNumber(), getZip());
+    }
+
+    public Address toAggregate() {
+        return new Address(
+                this.getStreet(),
+                this.getNumber(),
+                this.getNeighborhood(),
+                this.getCity(),
+                this.getState(),
+                this.getZip()
+        );
+    }
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientContactJpaEntity.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientContactJpaEntity.java
@@ -1,0 +1,75 @@
+package org.diegosneves.exactprocmmsbackend.infrastructure.client.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
+import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.ClientContact;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "client_contacts")
+@NoArgsConstructor
+public class ClientContactJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "email", nullable = false)
+    private String email;
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    private ClientContactJpaEntity(final String email, final String phone) {
+        this.email = email;
+        this.phone = phone;
+    }
+
+    public static ClientContactJpaEntity from(final ClientContact aContact) {
+        return new ClientContactJpaEntity(aContact.getEmail(), aContact.getPhone());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(final String phone) {
+        this.phone = phone;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientContactJpaEntity that = (ClientContactJpaEntity) o;
+        return Objects.equals(getEmail(), that.getEmail()) && Objects.equals(getPhone(), that.getPhone());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getEmail(), getPhone());
+    }
+
+    public ClientContact toAggregate() {
+        return new ClientContact(this.getEmail(), this.getPhone());
+    }
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientContactJpaEntity.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientContactJpaEntity.java
@@ -6,7 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.diegosneves.exactprocmmsbackend.domain.client.valueobject.ClientContact;
 
 import java.util.Objects;
@@ -14,6 +16,8 @@ import java.util.Objects;
 @Entity
 @Table(name = "client_contacts")
 @NoArgsConstructor
+@Getter
+@Setter
 public class ClientContactJpaEntity {
 
     @Id
@@ -31,30 +35,6 @@ public class ClientContactJpaEntity {
 
     public static ClientContactJpaEntity from(final ClientContact aContact) {
         return new ClientContactJpaEntity(aContact.getEmail(), aContact.getPhone());
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(final Long id) {
-        this.id = id;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(final String email) {
-        this.email = email;
-    }
-
-    public String getPhone() {
-        return phone;
-    }
-
-    public void setPhone(final String phone) {
-        this.phone = phone;
     }
 
     @Override

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientJpaEntity.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientJpaEntity.java
@@ -1,0 +1,133 @@
+package org.diegosneves.exactprocmmsbackend.infrastructure.client.persistence;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
+import org.diegosneves.exactprocmmsbackend.domain.client.Client;
+import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
+
+@Entity
+@Table(name = "clients")
+@NoArgsConstructor
+public class ClientJpaEntity {
+
+    @Id
+    private String id;
+    @Column(name = "cnpj", nullable = false)
+    private String cnpj;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "address_id", referencedColumnName = "id")
+    private AddressJpaEntity address;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "contact_id", referencedColumnName = "id")
+    private ClientContactJpaEntity contact;
+    @Column(name = "companyName", nullable = false)
+    private String companyName;
+    @Column(name = "companyBranch", nullable = false)
+    private String companyBranch;
+    @Column(name = "companySector", nullable = false)
+    private String companySector;
+
+    private ClientJpaEntity(
+            final String id,
+            final String cnpj,
+            final AddressJpaEntity address,
+            final ClientContactJpaEntity contact,
+            final String companyName,
+            final String companyBranch,
+            final String companySector) {
+        this.id = id;
+        this.cnpj = cnpj;
+        this.address = address;
+        this.contact = contact;
+        this.companyName = companyName;
+        this.companyBranch = companyBranch;
+        this.companySector = companySector;
+    }
+
+    public static ClientJpaEntity from(final Client aClient) {
+        return new ClientJpaEntity(
+                aClient.getId().getValue(),
+                aClient.getCnpj(),
+                AddressJpaEntity.from(aClient.getAddress()),
+                ClientContactJpaEntity.from(aClient.getContact()),
+                aClient.getCompanyName(),
+                aClient.getCompanyBranch(),
+                aClient.getCompanySector()
+        );
+    }
+
+    public Client toAggregate() {
+        return Client.with(
+                ClientID.from(this.getId()),
+                this.getCnpj(),
+                this.getAddress().toAggregate(),
+                this.getContact().toAggregate(),
+                this.getCompanyName(),
+                this.getCompanyBranch(),
+                this.getCompanySector()
+        );
+    }
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCnpj() {
+        return cnpj;
+    }
+
+    public void setCnpj(String cnpj) {
+        this.cnpj = cnpj;
+    }
+
+    public AddressJpaEntity getAddress() {
+        return address;
+    }
+
+    public void setAddress(AddressJpaEntity address) {
+        this.address = address;
+    }
+
+    public ClientContactJpaEntity getContact() {
+        return contact;
+    }
+
+    public void setContact(ClientContactJpaEntity contact) {
+        this.contact = contact;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getCompanyBranch() {
+        return companyBranch;
+    }
+
+    public void setCompanyBranch(String companyBranch) {
+        this.companyBranch = companyBranch;
+    }
+
+    public String getCompanySector() {
+        return companySector;
+    }
+
+    public void setCompanySector(String companySector) {
+        this.companySector = companySector;
+    }
+}

--- a/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientJpaEntity.java
+++ b/src/main/java/org/diegosneves/exactprocmmsbackend/infrastructure/client/persistence/ClientJpaEntity.java
@@ -7,13 +7,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.diegosneves.exactprocmmsbackend.domain.client.Client;
 import org.diegosneves.exactprocmmsbackend.domain.client.ClientID;
 
 @Entity
 @Table(name = "clients")
 @NoArgsConstructor
+@Getter
+@Setter
 public class ClientJpaEntity {
 
     @Id
@@ -74,60 +78,4 @@ public class ClientJpaEntity {
         );
     }
 
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getCnpj() {
-        return cnpj;
-    }
-
-    public void setCnpj(String cnpj) {
-        this.cnpj = cnpj;
-    }
-
-    public AddressJpaEntity getAddress() {
-        return address;
-    }
-
-    public void setAddress(AddressJpaEntity address) {
-        this.address = address;
-    }
-
-    public ClientContactJpaEntity getContact() {
-        return contact;
-    }
-
-    public void setContact(ClientContactJpaEntity contact) {
-        this.contact = contact;
-    }
-
-    public String getCompanyName() {
-        return companyName;
-    }
-
-    public void setCompanyName(String companyName) {
-        this.companyName = companyName;
-    }
-
-    public String getCompanyBranch() {
-        return companyBranch;
-    }
-
-    public void setCompanyBranch(String companyBranch) {
-        this.companyBranch = companyBranch;
-    }
-
-    public String getCompanySector() {
-        return companySector;
-    }
-
-    public void setCompanySector(String companySector) {
-        this.companySector = companySector;
-    }
 }

--- a/src/test/java/org/diegosneves/exactprocmmsbackend/domain/client/ClientTest.java
+++ b/src/test/java/org/diegosneves/exactprocmmsbackend/domain/client/ClientTest.java
@@ -249,6 +249,28 @@ class ClientTest {
         assertEquals("Company sector is required", actualException.getErrors().get(0).message());
     }
 
+    @Test
+    void givenAClientValidWhenCallTheWithMethodThenShouldReturnAClient() {
+        final String cnpj = "24888114000188";
+        final String companyName = "Company Name";
+        final String companyBranch = "Esteio/RS";
+        final String companySector = "Caldeiraria / Funelaria";
+
+        final var aClient = Client.newClient(cnpj, null, null, companyName, companyBranch, companySector);
+
+        final var actual = Client.with(aClient);
+
+        assertNotNull(actual);
+        assertDoesNotThrow(() -> actual.validate(new ThrowsValidationHandler()));
+        assertNotNull(actual.getId());
+        assertNotNull(actual.getId().getValue());
+        assertEquals(cnpj, actual.getCnpj());
+        assertEquals(companyName, actual.getCompanyName());
+        assertEquals(companyBranch, actual.getCompanyBranch());
+        assertEquals(companySector, actual.getCompanySector());
+
+    }
+
 
 
 }


### PR DESCRIPTION
**Commit** 379520c4dcb1347016be78c5d4eb412ee0819337:

Este commit adiciona novas entidades JPA para `Client`, `Address` e `ClientContact` para gerenciar a persistência. Ajustes foram feitos na classe `Client` para incluir métodos estáticos de criação, com a finalidade de facilitar o mapeamento do domínio para as entidades.

**Arquivos Alterados:** `ClientJpaEntity.java`, `AddressJpaEntity.java`, `ClientContactJpaEntity.java`, `Client.java`

**Alterações:**

- Criação da classe `ClientJpaEntity` com mapeamentos para os atributos de `Client`, incluindo relações `OneToOne` com `AddressJpaEntity` e `ClientContactJpaEntity`.
- Criação das classes `AddressJpaEntity` e `ClientContactJpaEntity` com mapeamentos para os atributos de `Address` e `ClientContact`.
- Ajuste na classe `Client` para incluir métodos estáticos de criação, facilitando o mapeamento do domínio para as entidades de persistência.
- Implementação das anotações `@Entity`, `@Table`, `@Id`, `@OneToOne`, `@JoinColumn`, entre outras, para gerenciar a persistência das novas entidades.

**Nota:** Este commit segue os princípios da Clean Architecture, mantendo a camada de domínio desacoplada dos detalhes de infraestrutura. As novas entidades JPA são criadas na camada de infraestrutura para gerenciar a persistência dos dados.

---
